### PR TITLE
Convert plugin to TypeScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/dist
+/node_modules

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,19 +1,23 @@
 module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
   env: {
     node: true,
     es6: true,
     "jest/globals": true,
   },
-  parserOptions: {
-    ecmaVersion: 9,
-  },
-  plugins: ["jest"],
+  plugins: ["@typescript-eslint", "jest"],
   extends: [
     "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:jest/recommended",
     "plugin:prettier/recommended",
   ],
   rules: {
     "jest/expect-expect": ["off"],
+    "@typescript-eslint/no-namespace": ["off"],
+
+    // Rules to disable in V5 port
+    "@typescript-eslint/no-var-requires": ["off"],
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /.idea
 /.yarn
 /.yarnrc.yml
+/dist
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-node_modules
-.idea
+/.git
+/.idea
+/.yarn
+/.yarnrc.yml
+/node_modules

--- a/__tests__/integration/queries.test.js
+++ b/__tests__/integration/queries.test.js
@@ -29,10 +29,10 @@ beforeAll(() => {
     // need and wait for them to be created in parallel.
     const [normal, columnAggregates] = await Promise.all([
       createPostGraphileSchema(pgClient, ["p"], {
-        appendPlugins: [require("../../index.js")],
+        appendPlugins: [require("../../dist/index.js")],
       }),
       createPostGraphileSchema(pgClient, ["p"], {
-        appendPlugins: [require("../../index.js")],
+        appendPlugins: [require("../../dist/index.js")],
         graphileBuildOptions: {
           orderByRelatedColumnAggregates: true,
         },

--- a/__tests__/integration/schema/columnAggregates.test.js
+++ b/__tests__/integration/schema/columnAggregates.test.js
@@ -3,7 +3,7 @@ const core = require("./core");
 test(
   "prints a schema with the order-by-related plugin",
   core.test(["p"], {
-    appendPlugins: [require("../../../index.js")],
+    appendPlugins: [require("../../../dist/index.js")],
     disableDefaultMutations: true,
     legacyRelations: "omit",
     graphileBuildOptions: {

--- a/__tests__/integration/schema/ignoreIndexes.test.js
+++ b/__tests__/integration/schema/ignoreIndexes.test.js
@@ -3,7 +3,7 @@ const core = require("./core");
 test(
   "prints a schema with `ignoreIndexes: false`",
   core.test(["p"], {
-    appendPlugins: [require("../../../index.js")],
+    appendPlugins: [require("../../../dist/index.js")],
     disableDefaultMutations: true,
     legacyRelations: "omit",
     ignoreIndexes: false,

--- a/__tests__/integration/schema/orderByRelated.test.js
+++ b/__tests__/integration/schema/orderByRelated.test.js
@@ -3,7 +3,7 @@ const core = require("./core");
 test(
   "prints a schema with the order-by-related plugin",
   core.test(["p"], {
-    appendPlugins: [require("../../../index.js")],
+    appendPlugins: [require("../../../dist/index.js")],
     disableDefaultMutations: true,
     legacyRelations: "omit",
   })

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,0 @@
-import type { Plugin } from "graphile-build";
-declare const PgOrderByRelatedPlugin: Plugin;
-export default PgOrderByRelatedPlugin;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",
     "eslint": "8.28.0",
+    "eslint-config-prettier": "8.5.0",
     "eslint-plugin-jest": "27.1.6",
     "eslint-plugin-prettier": "4.2.1",
     "graphql": "15.8.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/graphile-contrib/pg-order-by-related/issues"
   },
   "devDependencies": {
+    "@tsconfig/node18": "^18.2.4",
     "eslint": "8.28.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-jest": "27.1.6",
@@ -30,7 +31,8 @@
     "jest": "29.3.1",
     "pg": "8.8.0",
     "postgraphile-core": "4.12.3",
-    "prettier": "2.8.0"
+    "prettier": "2.8.0",
+    "typescript": "^5.7.2"
   },
   "jest": {
     "testRegex": "__tests__/.*\\.test\\.js$"

--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
   "name": "@graphile-contrib/pg-order-by-related",
   "version": "1.0.0",
   "description": "Order by related columns on PostGraphile connections",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "format": "prettier --ignore-path ./.eslintignore",
     "format:all": "yarn format '**/*.{json,md,html,js,jsx,ts,tsx}'",
     "format:fix": "yarn format:all --write",
     "format:check": "yarn format:all --list-different",
-    "lint": "eslint . --ext .js,.jsx",
-    "test": "scripts/test"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "prepack": "tsc",
+    "test": "tsc && scripts/test"
   },
   "repository": {
     "type": "git",
@@ -38,7 +39,6 @@
     "testRegex": "__tests__/.*\\.test\\.js$"
   },
   "files": [
-    "index.js",
-    "index.d.ts"
+    "dist"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.4",
+    "@typescript-eslint/eslint-plugin": "5.59.0",
+    "@typescript-eslint/parser": "5.59.0",
     "eslint": "8.28.0",
-    "eslint-config-prettier": "8.5.0",
     "eslint-plugin-jest": "27.1.6",
     "eslint-plugin-prettier": "4.2.1",
     "graphql": "15.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
-function PgOrderByRelatedPlugin(builder, { orderByRelatedColumnAggregates }) {
+import type { Inflection, Plugin } from "graphile-build";
+
+const PgOrderByRelatedPlugin: Plugin = (
+  builder,
+  { orderByRelatedColumnAggregates }
+) => {
   builder.hook("build", (build) => {
-    const pkg = require("./package.json");
+    const pkg = require("../package.json");
 
     // Check dependencies
     if (!build.versions) {
@@ -8,7 +13,7 @@ function PgOrderByRelatedPlugin(builder, { orderByRelatedColumnAggregates }) {
         `Plugin ${pkg.name}@${pkg.version} requires graphile-build@^4.1.0 in order to check dependencies (current version: ${build.graphileBuildVersion})`
       );
     }
-    const depends = (name, range) => {
+    const depends = (name: string, range: string) => {
       if (!build.hasVersion(name, range)) {
         throw new Error(
           `Plugin ${pkg.name}@${pkg.version} requires ${name}@${range} (${
@@ -29,7 +34,13 @@ function PgOrderByRelatedPlugin(builder, { orderByRelatedColumnAggregates }) {
 
   builder.hook("inflection", (inflection) => {
     return Object.assign(inflection, {
-      orderByRelatedColumnEnum(attr, ascending, foreignTable, keyAttributes) {
+      orderByRelatedColumnEnum(
+        this: Inflection,
+        attr,
+        ascending,
+        foreignTable,
+        keyAttributes
+      ) {
         return `${this.constantCase(
           `${this._singularizedTableName(foreignTable)}-by-${keyAttributes
             .map((keyAttr) => this._columnName(keyAttr))
@@ -37,6 +48,7 @@ function PgOrderByRelatedPlugin(builder, { orderByRelatedColumnAggregates }) {
         )}__${this.orderByColumnEnum(attr, ascending)}`;
       },
       orderByRelatedComputedColumnEnum(
+        this: Inflection,
         pseudoColumnName,
         proc,
         ascending,
@@ -54,7 +66,12 @@ function PgOrderByRelatedPlugin(builder, { orderByRelatedColumnAggregates }) {
           ascending
         )}`;
       },
-      orderByRelatedCountEnum(ascending, foreignTable, keyAttributes) {
+      orderByRelatedCountEnum(
+        this: Inflection,
+        ascending,
+        foreignTable,
+        keyAttributes
+      ) {
         return `${this.constantCase(
           `${this.pluralize(
             this._singularizedTableName(foreignTable)
@@ -64,6 +81,7 @@ function PgOrderByRelatedPlugin(builder, { orderByRelatedColumnAggregates }) {
         )}__${this.constantCase(`count-${ascending ? "asc" : "desc"}`)}`;
       },
       orderByRelatedColumnAggregateEnum(
+        this: Inflection,
         attr,
         ascending,
         foreignTable,
@@ -514,9 +532,6 @@ function PgOrderByRelatedPlugin(builder, { orderByRelatedColumnAggregates }) {
     const pseudoColumnName = proc.name.substr(table.name.length + 1);
     return { argTypes, pseudoColumnName };
   }
-}
+};
 
-module.exports = PgOrderByRelatedPlugin;
-// Hacks for TypeScript/Babel import
-module.exports.default = PgOrderByRelatedPlugin;
-Object.defineProperty(module.exports, "__esModule", { value: true });
+export default PgOrderByRelatedPlugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -535,3 +535,8 @@ const PgOrderByRelatedPlugin: Plugin = (
 };
 
 export default PgOrderByRelatedPlugin;
+
+// HACK: for TypeScript/Babel import
+module.exports = PgOrderByRelatedPlugin;
+module.exports.default = PgOrderByRelatedPlugin;
+Object.defineProperty(module.exports, "__esModule", { value: true });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "compilerOptions": {
+    "noImplicitAny": false,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,6 +1372,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-config-prettier@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
 eslint-plugin-jest@27.1.6:
   version "27.1.6"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.1.6.tgz#361d943f07d1978838e6b852c44a579f3879e332"

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,6 +716,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@tsconfig/node18@^18.2.4":
+  version "18.2.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node18/-/node18-18.2.4.tgz#094efbdd70f697d37c09f34067bf41bc4a828ae3"
+  integrity sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==
+
 "@types/babel__core@^7.1.14":
   version "7.1.20"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.20.tgz#e168cdd612c92a2d335029ed62ac94c95b362359"
@@ -3015,6 +3020,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+typescript@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 update-browserslist-db@^1.0.9:
   version "1.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,6 +369,18 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz#d1145bf2c20132d6400495d6df4bf59362fd9d56"
+  integrity sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
+  integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
+
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"
@@ -826,6 +838,32 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/eslint-plugin@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz#c0e10eeb936debe5d1c3433cf36206a95befefd0"
+  integrity sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==
+  dependencies:
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.59.0"
+    "@typescript-eslint/type-utils" "5.59.0"
+    "@typescript-eslint/utils" "5.59.0"
+    debug "^4.3.4"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/parser@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.0.tgz#0ad7cd019346cc5d150363f64869eca10ca9977c"
+  integrity sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.59.0"
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/typescript-estree" "5.59.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.45.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.45.0.tgz#7a4ac1bfa9544bff3f620ab85947945938319a96"
@@ -834,10 +872,33 @@
     "@typescript-eslint/types" "5.45.0"
     "@typescript-eslint/visitor-keys" "5.45.0"
 
+"@typescript-eslint/scope-manager@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz#86501d7a17885710b6716a23be2e93fc54a4fe8c"
+  integrity sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/visitor-keys" "5.59.0"
+
+"@typescript-eslint/type-utils@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz#8e8d1420fc2265989fa3a0d897bde37f3851e8c9"
+  integrity sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.59.0"
+    "@typescript-eslint/utils" "5.59.0"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/types@5.45.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.45.0.tgz#794760b9037ee4154c09549ef5a96599621109c5"
   integrity sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==
+
+"@typescript-eslint/types@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.0.tgz#3fcdac7dbf923ec5251545acdd9f1d42d7c4fe32"
+  integrity sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==
 
 "@typescript-eslint/typescript-estree@5.45.0":
   version "5.45.0"
@@ -851,6 +912,33 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz#8869156ee1dcfc5a95be3ed0e2809969ea28e965"
+  integrity sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/visitor-keys" "5.59.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.0.tgz#063d066b3bc4850c18872649ed0da9ee72d833d5"
+  integrity sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.59.0"
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/typescript-estree" "5.59.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
 
 "@typescript-eslint/utils@^5.10.0":
   version "5.45.0"
@@ -872,6 +960,14 @@
   integrity sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==
   dependencies:
     "@typescript-eslint/types" "5.45.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz#a59913f2bf0baeb61b5cfcb6135d3926c3854365"
+  integrity sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
     eslint-visitor-keys "^3.3.0"
 
 acorn-jsx@^5.3.2:
@@ -1276,11 +1372,6 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-prettier@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
-  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
-
 eslint-plugin-jest@27.1.6:
   version "27.1.6"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.1.6.tgz#361d943f07d1978838e6b852c44a579f3879e332"
@@ -1327,6 +1418,11 @@ eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
 eslint@8.28.0:
   version "8.28.0"
@@ -2440,6 +2536,11 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This is _not_ strongly typed TypeScript. It's just to minimize the diff vs V5 port (V5 has much much better typings across the plugin ecosystem).