### PR TITLE
Update README for PostGraphile v5 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [![Package on npm](https://img.shields.io/npm/v/@graphile-contrib/pg-order-by-related.svg)](https://www.npmjs.com/package/@graphile-contrib/pg-order-by-related)
 
-This Graphile Engine plugin adds additional enum values to the `orderBy` argument on connections, allowing you to order by columns in related tables.
+This plugin adds additional enum values to the `orderBy` argument on
+connections, allowing you to order by columns in related tables.
 
-> Requires `postgraphile@^4.3.1` or `graphile-build-pg@^4.3.1`
+> Requires `postgraphile@^5.0.0`
 
 Example:
 
@@ -28,61 +29,38 @@ One-to-one and many-to-one relations are supported. For one-to-many relations, `
 
 ## Usage
 
-Append this plugin and the additional `orderBy` options will be added to your schema.
+Add the plugin to the `plugins` list in your Graphile config:
 
-### CLI
+```ts
+import { makePgService } from "postgraphile/adaptors/pg";
+import { PostGraphileAmberPreset } from "postgraphile/presets/amber";
+import { PgOrderByRelatedPlugin } from "@graphile-contrib/pg-order-by-related";
 
-```bash
-yarn add postgraphile
-yarn add @graphile-contrib/pg-order-by-related
-npx postgraphile --append-plugins @graphile-contrib/pg-order-by-related
-```
+const preset: GraphileConfig.Preset = {
+  extends: [PostGraphileAmberPreset],
+  plugins: [PgOrderByRelatedPlugin],
+  pgServices: [
+    makePgService({
+      connectionString: process.env.DATABASE_URL!,
+      schemas: ["app_public"],
+    }),
+  ],
+};
 
-### Library
-
-```js
-const express = require("express");
-const { postgraphile } = require("postgraphile");
-const PgOrderByRelatedPlugin = require("@graphile-contrib/pg-order-by-related");
-
-const app = express();
-
-app.use(
-  postgraphile(process.env.DATABASE_URL, "app_public", {
-    appendPlugins: [PgOrderByRelatedPlugin],
-    graphiql: true,
-  })
-);
-
-app.listen(5000);
+export default preset;
 ```
 
 ## Inflection
 
-To avoid naming conflicts, this plugin uses a `<TABLE>_BY_<KEY>` naming convention (e.g. `USER_BY_AUTHOR_ID__CREATED_AT_ASC`), similar to how related fields are named by default in PostGraphile v4.
+To avoid naming conflicts, this plugin uses a `<TABLE>_BY_<KEY>` naming
+convention (e.g. `USER_BY_AUTHOR_ID__CREATED_AT_ASC`).
 
-You can override this by adding an inflector plugin. For example, the following plugin shortens the names by dropping the `<TABLE>_BY` portion (producing e.g. `AUTHOR_ID__CREATED_AT_ASC`):
-
-```js
-const { makeAddInflectorsPlugin } = require("graphile-utils");
-
-module.exports = makeAddInflectorsPlugin(
-  {
-    orderByRelatedColumnEnum(attr, ascending, foreignTable, keyAttributes) {
-      return `${this.constantCase(
-        keyAttributes.map((keyAttr) => this._columnName(keyAttr)).join("-and-")
-      )}__${this.orderByColumnEnum(attr, ascending)}`;
-    },
-  },
-  true // Passing true here allows the plugin to overwrite existing inflectors.
-);
-```
-
-See the [makeAddInflectorsPlugin documentation](https://www.graphile.org/postgraphile/make-add-inflectors-plugin/) for more information.
+You can override this with a custom V5 inflection plugin if you want shorter or
+more domain-specific enum names. See the
+[inflection documentation](https://postgraphile.org/postgraphile/next/inflection)
+for the current plugin patterns.
 
 ## Options
-
-When using PostGraphile as a library, the following options can be specified via `graphileBuildOptions`.
 
 ### orderByRelatedColumnAggregates
 
@@ -90,12 +68,14 @@ Adds additional enum values for column aggregates (currently `min` and `max`) fo
 
 Example:
 
-```js
-postgraphile(pgConfig, schema, {
-  graphileBuildOptions: {
+```ts
+const preset: GraphileConfig.Preset = {
+  extends: [PostGraphileAmberPreset],
+  plugins: [PgOrderByRelatedPlugin],
+  schema: {
     orderByRelatedColumnAggregates: true,
   },
-});
+};
 ```
 
 ```graphql


### PR DESCRIPTION
Updates the README usage/config examples to match PostGraphile V5.

- move setup guidance to graphile.config usage
- use the current preset/export names
- remove or update V4-era setup details